### PR TITLE
[DEVOPS-153] feat: remove auth json file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -57,6 +57,17 @@ function install_vim() {
 
 install_vim
 
+function remove_auth_json() {
+    echo "-----> Remove auth.json"
+    pwd 
+    ls -la
+    echo "Build Directory: ${BUILD_DIR}"
+    rm -f "${BUILD_DIR}/auth.json"
+    ls -la
+}
+
+remove_auth_json
+
 echo "-----> Writing Aptfile..."
 cat <<-EOF > "$BUILD_DIR/Aptfile"
 msmtp

--- a/bin/compile
+++ b/bin/compile
@@ -59,9 +59,6 @@ install_vim
 
 function remove_auth_json() {
     echo "-----> Remove auth.json"
-    pwd 
-    ls -la
-    echo "Build Directory: ${BUILD_DIR}"
     rm -f "${BUILD_DIR}/auth.json"
     ls -la
 }

--- a/bin/compile
+++ b/bin/compile
@@ -60,7 +60,6 @@ install_vim
 function remove_auth_json() {
     echo "-----> Remove auth.json"
     rm -f "${BUILD_DIR}/auth.json"
-    ls -la
 }
 
 remove_auth_json


### PR DESCRIPTION
# Summary

This PR adds an extra operation to buildpack: the removal of `auth.json` during Dokku builds.

# Why
Currently, credentials are being exposed in `auth.json` by the apps deployed to Dokku. For example:
![Screenshot 2026-01-23 at 20 15 39](https://github.com/user-attachments/assets/1a130ec4-12ca-41fe-a674-31eb1424403c)

# Details
Dokku executes the Heroku buildpack lifecycle on every `git push`, and our apps currently run:
1. https://github.com/heroku/heroku-buildpack-php.git
2. https://github.com/moderntribe/heroku-buildpack-sq1.git
3. https://github.com/heroku/heroku-buildpack-apt.git

In this change, I modified the `compile` script of our SquareOne buildpack (2) to explicitly remove `auth.json` during the build process.

The goal of this PR is to implement a centralized way to harden `auth.json` handling, preventing Dokku apps from accidentally serving wrong files and leaking credentials.

# Expected Result
With the changes proposed in this PR, `auth.json` will no longer exist and therefore won't be served. 
As a result, requests like `https://moose-dev-pr288.d1.moderntribe.qa/auth.json` will be redirected to the login page `https://moose-dev-pr288.d1.moderntribe.qa/wp-login.php`