### PR TITLE
Fix/remove cli install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Heroku Buildpack for SQ1
 
-Installs SQ1 and WordPress utilities and dependencies:
+Installs WordPress utilities and dependencies:
 
-* WPCLI
 * Vim
 * msmtp

--- a/bin/compile
+++ b/bin/compile
@@ -20,25 +20,6 @@ function setup_profile() {
 
 setup_profile
 
-function install_wp_cli() {
-    cd "${BUILD_DIR}"
-    echo "Build Directory: ${BUILD_DIR}"
-    mkdir -p "${BUILD_DIR}/.heroku/wp/bin/"
-
-    echo "-----> Install WP-CLI"
-    curl --retry 2 --silent --max-time 60 --location https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o "${BUILD_DIR}/.heroku/wp/bin/wp"
-    chmod +x "$BUILD_DIR/.heroku/wp/bin/wp"
-    "$BUILD_DIR/.heroku/wp/bin/wp" --info
-
-    echo 'export PATH=$PATH:$HOME/.heroku/wp/bin' > "${BUILD_DIR}/.profile.d/wpcli.sh"
-
-    # also copy to old path for backward compatibility
-    mkdir -p "${BUILD_DIR}/.wpcli"
-    cp "$BUILD_DIR/.heroku/wp/bin/wp" "${BUILD_DIR}/.wpcli/wp"
-}
-
-install_wp_cli
-
 function install_vim() {
 
     VIM_FILENAME='vim-static.tar.gz'


### PR DESCRIPTION
Currently, we rely on WP-CLI to be installed via composer within the application because we use it to install WordPress, thus this WP-CLI install isn't even used by our apps.

However, we want to move the WP-CLI before the PHP buildpack so that we can remove WP-CLI as an application-specific composer dependency.

I've [created a new buildpack specifically for the WP-CLI install](https://github.com/moderntribe/heroku-buildpack-wp-cli) and will insert it before the php buildpack is triggered by Ansible ([here](https://github.com/moderntribe/dokku-ansible/blob/master/ansible/roles/tribe_apps/tasks/wordpress.yml#L121-L124)). [Related PR](https://github.com/moderntribe/dokku-ansible/pull/90)